### PR TITLE
Improve guess_bed_cols

### DIFF
--- a/quilt.py
+++ b/quilt.py
@@ -141,9 +141,9 @@ class Table(object):
             elif not self._chr and 'chr' in name:
                 self._chr = c['id']
 
-            if 'start' in name:
+            if 'start' in name and not self._start:
                 self._start = c['id']
-            elif 'end' in name:
+            elif 'end' in name and not self._end:
                 self._end = c['id']
             elif not self._end and 'stop' in name:
                 self._end = c['id']                


### PR DESCRIPTION
Improve bed-file column (chromosome, start, end) guessing by choosing
the first column to have ‘start’ or ‘end’ instead of the last (e.g.
Block Starts)